### PR TITLE
Fix file case: required for case-sensitive file systems

### DIFF
--- a/Server/Scripts/vorlon.server.ts
+++ b/Server/Scripts/vorlon.server.ts
@@ -8,7 +8,7 @@ import path = require("path");
 var fakeredis = require("fakeredis");
 
 var winstonDisplay = require("winston-logs-display");
-import redisConfigImport = require("../config/VORLON.RedisConfig");
+import redisConfigImport = require("../config/vorlon.redisconfig");
 var redisConfig = redisConfigImport.VORLON.RedisConfig;
 
 //Vorlon


### PR DESCRIPTION
Unix is case sensitive, unlike OSX/windows. Just tried running everything on a unix
box and found this error.