### PR TITLE
Switching to break-word for CSS prop/value text

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -75,9 +75,7 @@
   color: #444;
 }
 .plugin-dom-explorer .styleLabel, .plugin-dom-explorer .styleValue {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  word-wrap: break-word;
 }
 .plugin-dom-explorer .styleLabel.editable,
 .plugin-dom-explorer .styleValue.editable {


### PR DESCRIPTION
Given the need to see all the text of properties values while scanning, and subsequently avoid requiring a further user interaction like hover or activate to reveal the full text, I believe it's best to make the property/value text wrap using `break-word`.