### PR TITLE
Updates to CSS panel of DOM explorer

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -63,19 +63,18 @@
   color: #007ca7;
 }
 .plugin-dom-explorer .styleLabel {
-  float: left;
-  clear: left;
-  width: 45%;
+  display: inline-block;
+  padding-right: 10px;
   color: #ed2424;
 }
-.plugin-dom-explorer .styleValue {
-  float: right;
-  width: 55%;
-  padding-left: 10px;
-  color: #444;
+.plugin-dom-explorer .styleLabel:after {
+  content: ":";
 }
-.plugin-dom-explorer .styleLabel, .plugin-dom-explorer .styleValue {
+.plugin-dom-explorer .styleValue {
+  display: inline;
+  color: #444;
   word-wrap: break-word;
+  vertical-align: top;
 }
 .plugin-dom-explorer .styleLabel.editable,
 .plugin-dom-explorer .styleValue.editable {
@@ -84,12 +83,11 @@
   outline: none;
 }
 .plugin-dom-explorer .styleButton {
-  float: left;
-  clear: left;
+  max-width: 100px;
+  margin: 10px auto 0;
   color: #444;
-  margin-left: -7px;
-  width: 20px;
   text-align: center;
+  background: #eee;
+  border-radius: 3px;
   cursor: pointer;
-  display: inline-block;
 }

--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -64,7 +64,8 @@
 }
 .plugin-dom-explorer .styleLabel {
   display: inline-block;
-  padding-right: 10px;
+  margin-right: 2px;
+  padding: 0 2px;
   color: #ed2424;
 }
 .plugin-dom-explorer .styleLabel:after {
@@ -72,6 +73,8 @@
 }
 .plugin-dom-explorer .styleValue {
   display: inline;
+  margin-left: 2px;
+  padding: 0 2px;
   color: #444;
   word-wrap: break-word;
   vertical-align: top;
@@ -80,7 +83,7 @@
 .plugin-dom-explorer .styleValue.editable {
   background-color: rgba(0,183,199,0.1);
   color: #666;
-  outline: none;
+  outline: 1px solid rgb(255, 20, 147);
 }
 .plugin-dom-explorer .styleButton {
   max-width: 100px;

--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -75,9 +75,7 @@
   color: #444;
 }
 .plugin-dom-explorer .styleLabel, .plugin-dom-explorer .styleValue {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  word-wrap: break-word;
 }
 .plugin-dom-explorer .styleLabel.editable,
 .plugin-dom-explorer .styleValue.editable {

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
@@ -258,15 +258,16 @@
 
         // Generate styles for a selected node
         private _generateStyle(property: string, value:string, internalId: string, editableLabel = false): void {
+            var wrap = document.createElement("div");
+            wrap.className = 'styleWrap';
             var label = document.createElement("div");
             label.innerHTML = property;
             label.className = "styleLabel";
             label.contentEditable = "false";
-            this._styleView.appendChild(label);
-
             var valueElement = this._generateClickableValue(label, value, internalId);
-
-            this._styleView.appendChild(valueElement);
+            wrap.appendChild(label);
+            wrap.appendChild(valueElement);
+            this._styleView.appendChild(wrap);
 
             if (editableLabel) {
                 label.addEventListener("blur", () => {


### PR DESCRIPTION
Changed the rule/prop/value text to flow visibly for easier editing, added outline, styled "add rule" element, added after pseudo content for showing ":" after property name.