### PR TITLE
updated lone textnodes in DOM Explorer to pring on 1 line

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -66,6 +66,15 @@
 .plugin-dom-explorer .nodeContentContainer {
   padding-left: 1em;
 }
+.plugin-dom-explorer .nodeContentContainer:not([data-has-children]),
+.plugin-dom-explorer .nodeContentContainer:not([data-has-children]) .treeNodeClosingText {
+  display: inline;
+  margin: 0;
+  padding: 0;
+}
+.plugin-dom-explorer .nodeContentContainer:not([data-has-children]) .nodeTextContent {
+  padding: 0 0.25em;
+}
 .plugin-dom-explorer .treeNodeSelected {
   background: yellow;
 }

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
@@ -376,11 +376,13 @@
                 if (this._spaceCheck.test(receivedObject.content)){
                     var textNode = document.createElement('span');
                     textNode.className = 'nodeTextContent';
-                    textNode.textContent = receivedObject.content;
+                    textNode.textContent = receivedObject.content.trim();
                     parentNode.appendChild(textNode);
                 }
             }
             else {
+                parentNode.setAttribute('data-has-children', '');
+                
                 var root = document.createElement("div");
                 parentNode.appendChild(root);
     


### PR DESCRIPTION
This change allows elements containing only textnodes to print their contents on a single line.

Looping in @deltakosh for review.