### PR TITLE
Added more console method hooks

### DIFF
--- a/Plugins/Vorlon/plugins/interactiveConsole/control.css
+++ b/Plugins/Vorlon/plugins/interactiveConsole/control.css
@@ -27,6 +27,12 @@
 .plugin-console .logMessage {
   color: #444;
 }
+.plugin-console .logDebug {
+  color: #b200ff;
+}
+.plugin-console .logInfo {
+  color: #0026ff;
+}
 .plugin-console .logWarning {
   color: #ff9205;
 }

--- a/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.ts
+++ b/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.ts
@@ -34,6 +34,28 @@
                 this._cache.push(data);
             });
 
+            Tools.Hook(window.console, "debug", (message: string): void => {
+                var data = {
+                    message: message,
+                    type: "debug"
+                };
+
+                Core.Messenger.sendRealtimeMessage(this.getID(), data, RuntimeSide.Client, "message", true);
+
+                this._cache.push(data);
+            });
+
+            Tools.Hook(window.console, "info", (message: string): void => {
+                var data = {
+                    message: message,
+                    type: "info"
+                };
+
+                Core.Messenger.sendRealtimeMessage(this.getID(), data, RuntimeSide.Client, "message", true);
+
+                this._cache.push(data);
+            });
+
             Tools.Hook(window.console, "warn",(message: string): void => {
                 var data = {
                     message: message,
@@ -137,6 +159,14 @@
                 case "log":
                     messageDiv.innerHTML = receivedObject.message;
                     Tools.AddClass(messageDiv, "logMessage");
+                    break;
+                case "debug":
+                    messageDiv.innerHTML = receivedObject.message;
+                    Tools.AddClass(messageDiv, "logDebug");
+                    break;
+                case "info":
+                    messageDiv.innerHTML = receivedObject.message;
+                    Tools.AddClass(messageDiv, "logInfo");
                     break;
                 case "warn":
                     messageDiv.innerHTML = receivedObject.message;

--- a/Plugins/samples/index.html
+++ b/Plugins/samples/index.html
@@ -50,6 +50,8 @@
     <h2>Console Logging</h2>
     <p>Console messages get logged to the Vorlon.JS dashboard. Try it!</p>
     <button onclick="console.log('This is a log message!')">console.log()</button>
+    <button onclick="console.debug('This is a debug message!')">console.debug()</button>
+    <button onclick="console.info('This is an info message!')">console.info()</button>
     <button onclick="console.warn('This is a warning!')">console.warn()</button>
     <button onclick="console.error('This is an error!')">console.error()</button>
 


### PR DESCRIPTION
Added hooks for `console.debug` and `console.info` in purple and blue respectively.
While hooked into an existing project I noticed that not all the log messages were being reported on the dashboard, this simple change adds the missing ones.