### PR TITLE
Move from hard-coded to N-generic attr printing

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -92,7 +92,7 @@
   padding-left: 0px;
 }
 .plugin-dom-explorer .nodeTextContent {
-  color: #555;
+  color: #777;
 }
 .plugin-dom-explorer .treeNodeClosingText {
   margin-left: -1.25em;
@@ -112,12 +112,20 @@
   color: #6B2D81;
 }
 .plugin-dom-explorer .nodeAttribute {
+  padding-left: 0.5em;
+}
+.plugin-dom-explorer .nodeAttribute span:first-child {
   color: #ed2424;
 }
-.plugin-dom-explorer .nodeValue {
+.plugin-dom-explorer .nodeAttribute span:first-child:after {
+  content: "=\"";
+  color: #6B2D81;
+}
+.plugin-dom-explorer .nodeAttribute span:last-child {
   color: #007ca7;
 }
-.plugin-dom-explorer .nodeTag {
+.plugin-dom-explorer .nodeAttribute span:last-child:after {
+  content: "\"";
   color: #6B2D81;
 }
 .plugin-dom-explorer .styleLabel {

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
@@ -87,6 +87,9 @@
                 name: node.localName,
                 classes: node.className,
                 content: node.textContent,
+                attributes: node.attributes ? Array.prototype.map.call(node.attributes, function(attr){
+                   return [attr.name, attr.value];
+                }) : [],
                 styles: this._getAppliedStyles(node),
                 internalId: this._internalId++
             };
@@ -343,19 +346,12 @@
         private _generateColorfullLink(link: HTMLAnchorElement, receivedObject: any): void {
             this._appendSpan(link, "nodeName", receivedObject.name);
             
-            if (receivedObject.id) {
-                this._appendSpan(link, "nodeAttribute", " id");
-                this._appendSpan(link, "nodeTag", "=\"");
-                this._appendSpan(link, "nodeValue", receivedObject.id);
-                this._appendSpan(link, "nodeTag", "\"");
-            }
-
-            if (receivedObject.classes) {
-                this._appendSpan(link, "nodeAttribute", " class");
-                this._appendSpan(link, "nodeTag", "=\"");
-                this._appendSpan(link, "nodeValue", receivedObject.classes);
-                this._appendSpan(link, "nodeTag", "\"");
-            }
+            receivedObject.attributes.forEach(function(attr){
+                var node = document.createElement('span');
+                node.className = 'nodeAttribute';
+                node.innerHTML = '<span>' + attr[0] + '</span><span>' + attr[1] + '</span>'; 
+                link.appendChild(node);
+            });
         }
           
         private _generateColorfullClosingLink(link: HTMLElement, receivedObject: any): void {

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
@@ -178,7 +178,7 @@ module VORLON {
                 switch (receivedObject.type) {
                     case "unselect":
                         if(this._lastElementSelectedClientSide){
-                            this._lastElementSelectedClientSide.style.border = this._lastElementSelectedClientSide.__savedBorder;
+                            this._lastElementSelectedClientSide.style.outline = this._lastElementSelectedClientSide.__savedOutline;
                         }
                         break;
                 }
@@ -193,12 +193,12 @@ module VORLON {
 
             switch (receivedObject.type) {
                 case "select":
-                    element.__savedBorder = element.style.border;
-                    element.style.border = "2px solid red";
+                    element.__savedOutline = element.style.outline;
+                    element.style.outline = "2px solid red";
                     this._lastElementSelectedClientSide = element;
                     break;
                 case "unselect":
-                    element.style.border = element.__savedBorder;
+                    element.style.outline = element.__savedOutline;
                     break;
                 case "ruleEdit":
                     element.style[receivedObject.property] = receivedObject.newValue;


### PR DESCRIPTION
This is a commit that addresses the need for more generic attribute printing to capture all attributes in the remote document's nodes without hard-coding against specific attributes. This feature addresses issue https://github.com/MicrosoftDX/Vorlonjs/issues/50.