### PR TITLE
Add start/end tag highlighting on hover

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.css
+++ b/Plugins/Vorlon/plugins/domExplorer/control.css
@@ -75,8 +75,13 @@
 .plugin-dom-explorer .nodeContentContainer:not([data-has-children]) .nodeTextContent {
   padding: 0 0.25em;
 }
-.plugin-dom-explorer .treeNodeSelected {
-  background: yellow;
+.plugin-dom-explorer [data-hovered-tag] > .treeNodeHeader,
+.plugin-dom-explorer [data-hovered-tag] > .nodeContentContainer > .treeNodeClosingText .nodeName {
+  background: cyan;
+}
+.plugin-dom-explorer .treeNodeSelected,
+.plugin-dom-explorer .treeNodeSelected ~ .nodeContentContainer > .treeNodeClosingText .nodeName {
+  background: yellow !important;
 }
 .plugin-dom-explorer .treeNodeTools {
   color: #444; 
@@ -95,16 +100,16 @@
   color: #777;
 }
 .plugin-dom-explorer .treeNodeClosingText {
-  margin-left: -1.25em;
-  padding-left: 1em;
+  margin-left: -0.25em;
   font-weight: bold;
   background: #fff;
+  cursor: default;
 }
-.plugin-dom-explorer .treeNodeClosingText:before {
+.plugin-dom-explorer .treeNodeClosingText .nodeName:before {
   content: "</";
   color: #000;
 }
-.plugin-dom-explorer .treeNodeClosingText:after {
+.plugin-dom-explorer .treeNodeClosingText .nodeName:after {
   content: ">";
   color: #000;
 }

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.ts
@@ -225,10 +225,28 @@ module VORLON {
                 
                 this._treeDiv.addEventListener('click', function(e){
                     var button = <HTMLElement>e.target;
-                    if (button.className && button.className == 'treeNodeButton') {
+                    if (button.className.match('treeNodeButton')) {
                         button.hasAttribute('data-collapsed') ? button.removeAttribute('data-collapsed') : button.setAttribute('data-collapsed', '');
                     }
                 });
+                
+                this._treeDiv.addEventListener('mouseenter', (e) => {
+                    var node = <HTMLElement>e.target;
+                    var isHeader = node.className.match('treeNodeHeader');
+                    if (isHeader || node.parentNode.className.match('treeNodeClosingText')) {
+                        var parent = <HTMLElement>node.parentNode;
+                        if (isHeader) parent.setAttribute('data-hovered-tag', '');
+                        else parent.parentNode.parentNode.setAttribute('data-hovered-tag', '');
+                    }
+                }, true);
+                
+                this._treeDiv.addEventListener('mouseleave', (e) => {
+                    var node = <HTMLElement>e.target;
+                    if (node.className.match('treeNodeHeader') || node.parentNode.className.match('treeNodeClosingText')) {
+                        var hovered = this._treeDiv.querySelector('[data-hovered-tag]')
+                        if (hovered) hovered.removeAttribute('data-hovered-tag');
+                    }
+                }, true);
                 
                 $('.dom-explorer-container').split({
                     orientation: 'vertical',


### PR DESCRIPTION
This pull provides tag-matched highlighting on hover to more easily understand the scope of content sections.