### PR TITLE
Update default Express string to be more descriptive

### DIFF
--- a/Server/Scripts/vorlon.webServer.ts
+++ b/Server/Scripts/vorlon.webServer.ts
@@ -78,7 +78,7 @@ export module VORLON {
             });
 
             this._httpServer = http.createServer(app).listen(app.get('port'),() => {
-                console.log('Express server listening on port ' + app.get('port'));
+                console.log('Vorlon listening on port ' + app.get('port'));
             });
 
             for (var id in this._components) {


### PR DESCRIPTION
Update the standard "Express server listening on port..." string to specify that it's Vorlon that's listening.