### PR TITLE
Tweaking DOM Explorer controlbar search elements

### DIFF
--- a/Plugins/Vorlon/plugins/domExplorer/control.html
+++ b/Plugins/Vorlon/plugins/domExplorer/control.html
@@ -10,10 +10,8 @@
         <div class="tree-view-wrapper panel-left">
             <x-controlbar>
                 <x-action event="refresh" tabindex="0"><i class="fa fa-circle"></i> Refresh</x-action>
-                <div class="searchContainer">
-                    <input type="text" placeholder="search node by css selector" id="searchinput" />
-                    <div id="searchresults"></div>
-                </div>
+                <input type="text" placeholder="search node by css selector" id="searchinput" />
+                <div id="searchresults"></div>
             </x-controlbar>
             <div id="treeView" class="code-text"></div>
             <div class="domload-spinner">

--- a/Plugins/Vorlon/plugins/domExplorer/control.less
+++ b/Plugins/Vorlon/plugins/domExplorer/control.less
@@ -195,7 +195,6 @@
     }
 
     #treeView {
-        display: none;
         height: ~"calc(100% - 36px)";
         overflow-x: none;
         overflow-y: auto;
@@ -258,60 +257,61 @@
         }
 
         &.active {
-
             .domload-spinner {
                 display: none;
             }
-
-            > x-controlbar,
-            #treeView {
-                display: block;
+        }
+        
+        &:not(.active) {
+            > x-controlbar, > #treeView {
+                display: none;
             }
         }
 
-        > x-controlbar {
-            display: none;
+        > x-controlbar {          
             border-top: none;
             border-left: none;
             border-right: none;
-            position: relative;
 
-            > * {
-                border-radius: 0.25em;
+            #searchresults {
+                display: none;
+                position: relative;
+                font-size: 70%;
+                font-weight: bold;
+                text-align: center;
+                
+                &:before {
+                    content: "";
+                    position: absolute;
+                    top: 50%;
+                    right: 0; 
+                    padding: 0 0.75em 0 0;
+                    -webkit-transform: translateY(-50%); 
+                    transform: translateY(-50%);
+                }
+
+                &.found {
+                    display: block;
+                    color: #777;
+                    
+                    &:before {
+                        content: attr(content);
+                    }   
+                }
+
+                &.noresults {
+                    display: block;
+                    color: #ed2424;
+                    
+                    &:before {
+                        content: "0/0";
+                    }
+                }
             }
 
-            .searchContainer {
-                position: absolute;
-                right: 0;
-                top: 0;
-                bottom: 0;
-                display: webkit-flex;
-                display: flex;
-
-                #searchresults {
-                    justify-content: center;
-                    line-height: 30px;
-                    padding-right: 5px;
-                    padding-left: 5px;
-                    color: white;
-                    margin-top: 0.25em;
-                    margin-bottom: 0.25em;
-
-                    &.found {
-                        background-color: black;
-                    }
-
-                    &.noresults {
-                        background-color: #ed2424;
-                    }
-                }
-
-                #searchinput {
-                    justify-content: center;
-                    margin-top: 0.25em;
-                    margin-bottom: 0.25em;
-                    min-width: 220px;
-                }
+            #searchinput {
+                min-width: 220px;
+                margin-left: auto;
             }
         }
     }

--- a/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.dashboard.ts
+++ b/Plugins/Vorlon/plugins/domExplorer/vorlon.domExplorer.dashboard.ts
@@ -259,11 +259,10 @@
                 if (this._lengthSearch) {
                     this._searchresults.classList.remove('noresults');
                     this._searchresults.classList.add('found');
-                    this._searchresults.innerHTML = this._positionSearch + "/" + this._lengthSearch;
+                    this._searchresults.setAttribute('content', this._positionSearch + "/" + this._lengthSearch);
                 } else {
                     this._searchresults.classList.remove('found');
                     this._searchresults.classList.add('noresults');
-                    this._searchresults.innerHTML = "no results";
                 }
             }
             else {

--- a/Server/public/stylesheets/components/dashboard.styl
+++ b/Server/public/stylesheets/components/dashboard.styl
@@ -171,7 +171,8 @@
   x-notify
     z-index: 1001;
     
-  x-controlbar > *
+  x-controlbar > *,
+  x-controlbar input
     border-radius: 0.25em
 
   .no-anim

--- a/Server/public/stylesheets/style.css
+++ b/Server/public/stylesheets/style.css
@@ -487,7 +487,8 @@ h4
 x-notify {
   z-index: 1001;
 }
-x-controlbar > * {
+x-controlbar > *,
+x-controlbar input {
   border-radius: 0.25em;
 }
 .no-anim {


### PR DESCRIPTION
This commit removes adds in the more friendly, single state `:not(.active)` approach to hide/show, as well as tweaks to the presentation of the selector element found UI (now it doesn't block view of the highlighted element that are always right below it when you toggle through the list)