### PR TITLE
Bind vorlon current instance location to the dashboard

### DIFF
--- a/Server/public/javascripts/dashboard.js
+++ b/Server/public/javascripts/dashboard.js
@@ -4,26 +4,29 @@ jQuery(function ($) {
         orientation: 'horizontal',
         limit: 38
     });
-    
+
+    // Replace default url with the current one (running vorlon)
+    $('#scriptSrc').text('<script src="{{location}}/vorlon.js"></script>'.replace('{{location}}', location.origin));
+
     //Plugin tab navigation
     $('#pluginsPaneTop').on('click', '[data-plugin-target]', function (e) {
         var $this = $(this);
         var target = $this.data('plugin-target');
-        
+
         $('#pluginsPaneTop [data-plugin-target]').removeClass('active');
         $this.addClass('active');
         $('#pluginsPaneTop [data-plugin]')
                     .hide()
                     .trigger("vorlon.plugins.inactive");
-        
+
         $('#pluginsPaneTop [data-plugin~=' + target + ']')
                     .show()
                     .trigger("vorlon.plugins.active");
     });
-    
+
     $('#pluginsPaneBottom').on('click', '[data-plugin-target]', function (e) {
         var target = $(this).data('plugin-target');
-        
+
         $('#pluginsPaneBottom [data-plugin-target]').removeClass('active');
         $(this).addClass('active');
         $('#pluginsPaneBottom [data-plugin]')

--- a/Server/views/includes/dashboard-plugins.jade
+++ b/Server/views/includes/dashboard-plugins.jade
@@ -6,9 +6,9 @@ section.dashboard-plugins-container
     section.panel-bottom#pluginsPaneBottom
       header.tab-bar.cf#pluginsListPaneBottom
   section.dashboard-plugins-overlay
-    div.message 
+    div.message
       img.logo(src="/images/VorlonLogo_Smooth.svg")
       h3 To get started, you must add a reference to client script in the page of your website, like this :
-      h4 &lt;script src=&quot;http://localhost:1337/vorlon.js&quot;&gt;&lt;/script&gt;
-      h3 Once your page is loaded, the client will appear in the sidebar on the left. 
-      h3 Click on it to start inspecting your website. 
+      h4#scriptSrc &lt;script src=&quot;http://localhost:1337/vorlon.js&quot;&gt;&lt;/script&gt;
+      h3 Once your page is loaded, the client will appear in the sidebar on the left.
+      h3 Click on it to start inspecting your website.


### PR DESCRIPTION
From:

```
TO GET STARTED, YOU MUST ADD A REFERENCE TO CLIENT SCRIPT IN THE PAGE OF YOUR WEBSITE, LIKE THIS :
<script src="http://localhost:1337/vorlon.js"></script>
```

To:
```
TO GET STARTED, YOU MUST ADD A REFERENCE TO CLIENT SCRIPT IN THE PAGE OF YOUR WEBSITE, LIKE THIS :
<script src="{http|https}://{ip}:{port:vorlon}/vorlon.js"></script>
```

*I don't run Vorlon with the default port and from localhost :balloon:*

> *Jamais 2 sans 3*