### PR TITLE
Added classname to the identify number

### DIFF
--- a/Plugins/Vorlon/vorlon.core.ts
+++ b/Plugins/Vorlon/vorlon.core.ts
@@ -226,7 +226,8 @@
             }
             else {
                 var div = document.createElement("div");
-                div.style.position = "absolute";
+		div.className = "vorlonIdentifyNumber";
+		div.style.position = "absolute";
                 div.style.left = "0";
                 div.style.top = "50%";
                 div.style.marginTop = "-150px";


### PR DESCRIPTION
It might be useful to have a class name on the identifier as some people might want to change the layout or hide the number for certain clients. The class name that I gave it is vorlonIdentifyNumber, cause I am pretty sure no one uses this class name in their project.
