### PR TITLE
Fix error when the babylon engine is not found

### DIFF
--- a/Plugins/Vorlon/plugins/babylonInspector/vorlon.babylonInspector.client.ts
+++ b/Plugins/Vorlon/plugins/babylonInspector/vorlon.babylonInspector.client.ts
@@ -763,7 +763,13 @@ module VORLON {
         * as the user switches between clients on the dashboard.
         */
         public refresh(): void {
-            this._sendScenesData();
+            if (this.engine) {
+                this._sendScenesData();
+            } else {
+                this.engine = this._getBabylonEngine();
+                this.scenes = this.engine.scenes;
+                this._sendScenesData();
+            }
         }
 
         /**


### PR DESCRIPTION
When the babylon engine is not found at vorlon start, it is never refreshed. This PR fixes this issue.