### PR TITLE
Add test result file for VSTS Build VNext

### DIFF
--- a/Tests/gulpfile.tests.js
+++ b/Tests/gulpfile.tests.js
@@ -6,5 +6,5 @@ var gulp = require('gulp'),
  */
 gulp.task('tests', function(){
    gulp.src('server.vorlon.tools.tests.js')
-    .pipe(mocha()); 
+    .pipe(mocha({reporter: 'mocha-junit-reporter'})); 
 });

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-webserver": "~0.9.0",
     "gulp-zip": "~3.0.2",
     "merge2": "~0.3.5",
+    "mocha-junit-reporter": "^1.9.1",
     "through": "~2.3.4",
     "typescript": "~1.6.0-beta"
   },


### PR DESCRIPTION
This change generates a test-results.xml file (in the Tests folder) that can be use in VSTS build VNext to export test result at the end of the build.