### PR TITLE
Update InteractiveConsole - reverse logs entries

### DIFF
--- a/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.dashboard.ts
+++ b/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.dashboard.ts
@@ -313,7 +313,8 @@
             this.entry = entry;
             this.element = document.createElement("div");
             this.element.className = 'log-entry ' + this.getTypeClass();
-            parent.insertBefore(this.element, parent.childNodes.length > 0 ? parent.childNodes[0] : null);
+            this.element.title = "Message received at " + new Date().toLocaleTimeString();
+            parent.appendChild(this.element);
 
             for (var i = 0, l = entry.messages.length; i < l; i++) {
                 this.addMessage(entry.messages[i]);


### PR DESCRIPTION
If the #324 improvement is approved, do the trick and also display the time when the log entry was received on hover.