### PR TITLE
Allow Config File to be Passed From CLI

### DIFF
--- a/Server/Scripts/vorlon.authentication.ts
+++ b/Server/Scripts/vorlon.authentication.ts
@@ -1,25 +1,26 @@
 import fs = require("fs");
 import path = require("path");
+import config = require("../config/vorlon.configprovider");
 
 export module VORLON {
     export class Authentication  {
         public static ActivateAuth: boolean = false;
         public static UserName: string;
         public static Password: string;
-        
-        public static ensureAuthenticated(req, res, next) { 
-            if (!Authentication.ActivateAuth || req.isAuthenticated()) { return next(); } 
+
+        public static ensureAuthenticated(req, res, next) {
+            if (!Authentication.ActivateAuth || req.isAuthenticated()) { return next(); }
             res.redirect('/login');
-        } 
-        
+        }
+
         public static loadAuthConfig(): void {
-             fs.readFile(path.join(__dirname, "../config.json"), "utf8",(err, catalogdata) => {
+             fs.readFile(config.VORLON.ConfigProvider.getConfigPath(), "utf8",(err, catalogdata) => {
                 if (err) {
                     return;
                 }
-                
+
                 var catalog = JSON.parse(catalogdata.replace(/^\uFEFF/, ''));
-                
+
                 if(catalog.activateAuth){
                     Authentication.ActivateAuth = catalog.activateAuth;
                 }

--- a/Server/Scripts/vorlon.dashboard.ts
+++ b/Server/Scripts/vorlon.dashboard.ts
@@ -8,16 +8,17 @@ var packageJson = require("../../package.json");
 //Vorlon
 import iwsc = require("./vorlon.IWebServerComponent");
 import vauth = require("./vorlon.authentication");
-import vorloncontext = require("../config/vorlon.servercontext"); 
+import vorloncontext = require("../config/vorlon.servercontext");
+import config = require("../config/vorlon.configprovider");
 
 export module VORLON {
     export class Dashboard implements iwsc.VORLON.IWebServerComponent {
         private baseURLConfig: vorloncontext.VORLON.IBaseURLConfig;
         private _log: vorloncontext.VORLON.ILogger;
-        
+
         constructor(context : vorloncontext.VORLON.IVorlonServerContext) {
-            this.baseURLConfig = context.baseURLConfig;   
-            this._log = context.logger;    
+            this.baseURLConfig = context.baseURLConfig;
+            this._log = context.logger;
         }
 
         public addRoutes(app: express.Express, passport: any): void {
@@ -28,18 +29,18 @@ export module VORLON {
             app.route(this.baseURLConfig.baseURL + '/dashboard/:sessionid/reset').get(vauth.VORLON.Authentication.ensureAuthenticated,this.dashboardServerReset());
             app.route(this.baseURLConfig.baseURL + '/dashboard/:sessionid/:clientid').get(vauth.VORLON.Authentication.ensureAuthenticated,this.dashboardWithClient());
             app.route(this.baseURLConfig.baseURL + '/config').get(vauth.VORLON.Authentication.ensureAuthenticated,this.dashboardConfig());
-            
+
             //login
-            app.post(this.baseURLConfig.baseURL + '/login',   
-                    passport.authenticate('local', 
+            app.post(this.baseURLConfig.baseURL + '/login',
+                    passport.authenticate('local',
                         { failureRedirect: '/login',
                           successRedirect: '/',
                           failureFlash: false })
                 );
-            
+
            app.route(this.baseURLConfig.baseURL + '/login').get((req: express.Request, res: express.Response) => {
                     res.render('login', { baseURL: this.baseURLConfig.baseURL, message: 'Please login' });
-                });  
+                });
            app.get(this.baseURLConfig.baseURL + '/logout', this.logout);
         }
 
@@ -57,13 +58,13 @@ export module VORLON {
         private dashboard() {
             return (req: express.Request, res: express.Response) => {
                 var authent = false;
-                var configastext = fs.readFileSync(path.join(__dirname, "../config.json"));
-                var catalog = JSON.parse(configastext.toString().replace(/^\uFEFF/, ''));   
-                
+                var configastext = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath());
+                var catalog = JSON.parse(configastext.toString().replace(/^\uFEFF/, ''));
+
                 if(catalog.activateAuth){
                     authent = catalog.activateAuth;
                 }
-                
+
                 this._log.debug("authenticated " + authent);
                 res.render('dashboard', { baseURL: this.baseURLConfig.baseURL, title: 'Dashboard', sessionid: req.params.sessionid, clientid: "", authenticated: authent, version: packageJson.version });
             }
@@ -74,7 +75,7 @@ export module VORLON {
                 res.render('dashboard', { baseURL: this.baseURLConfig.baseURL, title: 'Dashboard', sessionid: req.params.sessionid, clientid: req.params.clientid, version: packageJson.version });
             }
         }
-        
+
         private dashboardConfig() {
             return (req: express.Request, res: express.Response) => {
                 res.render('config', { baseURL: this.baseURLConfig.baseURL, title: 'Configuration', sessionid: "default", clientid: "", version: packageJson.version });
@@ -86,7 +87,7 @@ export module VORLON {
                  res.render('getsession', { title: 'Get Session' });
             }
         }
-        
+
         private logout(req: any, res: any) {
             req.logout();
             res.redirect('/');
@@ -103,7 +104,7 @@ export module VORLON {
                         }
                     }
                 }
-    
+
                 xhr.open("GET", "http://" + req.headers.host + this.baseURLConfig.baseURL + "/api/reset/" + sessionid);
                 xhr.send();
             }

--- a/Server/config/vorlon.baseurlconfig.ts
+++ b/Server/config/vorlon.baseurlconfig.ts
@@ -1,14 +1,15 @@
 import fs = require("fs");
 import path = require("path");
+import config = require("./vorlon.configprovider");
 
 export module VORLON {
     export class BaseURLConfig {
-		
+
 		public baseURL: string;
 		public baseProxyURL : string;
-		
+
 		constructor() {
-			var catalogdata: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");            
+			var catalogdata: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var catalogstring = catalogdata.toString().replace(/^\uFEFF/, '');
             var catalog = JSON.parse(catalogstring);
 			if (catalog.baseURL != undefined) {
@@ -17,7 +18,7 @@ export module VORLON {
 			else {
 				this.baseURL = "";
 			}
-			
+
 			if (catalog.baseProxyURL != undefined) {
 				this.baseProxyURL = catalog.baseProxyURL;
 			}

--- a/Server/config/vorlon.configprovider.ts
+++ b/Server/config/vorlon.configprovider.ts
@@ -1,0 +1,10 @@
+import fs = require("fs");
+import path = require("path");
+
+var argv = require('minimist')(process.argv.slice(2));
+
+export module VORLON {
+  export class ConfigProvider {
+
+  }
+}

--- a/Server/config/vorlon.configprovider.ts
+++ b/Server/config/vorlon.configprovider.ts
@@ -5,6 +5,8 @@ var argv = require('minimist')(process.argv.slice(2));
 
 export module VORLON {
   export class ConfigProvider {
-
+    public static config(): string {
+        return argv.config ? path.join(process.cwd(), argv.config) : path.join(__dirname, "../config.json");
+    }
   }
 }

--- a/Server/config/vorlon.configprovider.ts
+++ b/Server/config/vorlon.configprovider.ts
@@ -5,7 +5,7 @@ var argv = require('minimist')(process.argv.slice(2));
 
 export module VORLON {
   export class ConfigProvider {
-    public static config(): string {
+    public static getConfigPath(): string {
         return argv.config ? path.join(process.cwd(), argv.config) : path.join(__dirname, "../config.json");
     }
   }

--- a/Server/config/vorlon.httpconfig.ts
+++ b/Server/config/vorlon.httpconfig.ts
@@ -2,6 +2,7 @@
 import http = require("http");
 import https = require("https");
 import path = require("path");
+import config = require("./vorlon.configprovider");
 
 export module VORLON {
     export class HttpConfig {
@@ -17,7 +18,7 @@ export module VORLON {
         public proxyEnvPort: boolean;
 
         public constructor() {
-            var catalogdata: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var catalogdata: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var catalogstring = catalogdata.toString().replace(/^\uFEFF/, '');
             var catalog = JSON.parse(catalogstring);
 

--- a/Server/config/vorlon.logconfig.ts
+++ b/Server/config/vorlon.logconfig.ts
@@ -1,5 +1,6 @@
 ﻿import fs = require("fs");
 import path = require("path");
+import config = require("./vorlon.configprovider");
 
 export module VORLON {
     export class LogConfig {
@@ -9,7 +10,7 @@ export module VORLON {
         public level: string;
 
         public constructor() {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
             if (configuration.logs) {

--- a/Server/config/vorlon.pluginsconfig.ts
+++ b/Server/config/vorlon.pluginsconfig.ts
@@ -1,18 +1,19 @@
 import fs = require("fs");
 import path = require("path");
 import ctx = require("./vorlon.servercontext");
+import config = require("./vorlon.configprovider");
 
 export module VORLON {
     export class PluginsConfig {
-        
+
         public constructor() {
-        }        
-        
+        }
+
         getPluginsFor(sessionid:string, callback:(error, plugins:ctx.VORLON.ISessionPlugins) => void) {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
-            
+
             try{
                 var sessionConfig = <ctx.VORLON.ISessionPlugins>configuration.sessions[sessionid];
             }
@@ -24,98 +25,98 @@ export module VORLON {
                     };
                 }
             }
-                
+
             if (callback)
                 callback(null, sessionConfig);
         }
-        
+
         setPluginState(pluginid:string, callback:(error) => void) {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
-            
+
             for (var i = 0; i < configuration.plugins.length; i++) {
                 if (configuration.plugins[i].id == pluginid) {
                     configuration.plugins[i].enabled = !configuration.plugins[i].enabled;
-                    fs.writeFileSync(path.join(__dirname, "../config.json"), JSON.stringify(configuration, null, 4) ,"utf8");
+                    fs.writeFileSync(config.VORLON.ConfigProvider.getConfigPath(), JSON.stringify(configuration, null, 4) ,"utf8");
                     return callback(null);
                 }
             }
-            
+
             return callback('PluginID unknown');
         }
-        
+
         setPluginName(pluginid:string, name:string, callback:(error) => void) {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
-            
+
             if(!name) {
                 return callback(true);
             }
-            
+
             for (var i = 0; i < configuration.plugins.length; i++) {
                 if (configuration.plugins[i].id == pluginid) {
                     configuration.plugins[i].name = name;
-                    fs.writeFileSync(path.join(__dirname, "../config.json"), JSON.stringify(configuration, null, 4) ,"utf8");
+                    fs.writeFileSync(config.VORLON.ConfigProvider.getConfigPath(), JSON.stringify(configuration, null, 4) ,"utf8");
                     return callback(null);
                 }
             }
-            
+
             return callback('PluginID unknown');
         }
-        
+
         setPluginPanel(pluginid:string, panel:string, callback:(error) => void) {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
             var panelPosible = ['top', 'bottom'];
             if(!panel) {
                 return callback('Panel must be defined');
             }
-            
+
             if (panelPosible.indexOf(panel) == -1) {
                 return callback('Panel wrong value');
             }
-            
+
             for (var i = 0; i < configuration.plugins.length; i++) {
                 if (configuration.plugins[i].id == pluginid) {
                     configuration.plugins[i].panel = panel;
-                    fs.writeFileSync(path.join(__dirname, "../config.json"), JSON.stringify(configuration, null, 4) ,"utf8");
+                    fs.writeFileSync(config.VORLON.ConfigProvider.getConfigPath(), JSON.stringify(configuration, null, 4) ,"utf8");
                     return callback(null);
                 }
             }
-            
+
             return callback('PluginID unknown');
         }
-        
+
         setPluginsPosition(positions:any, callback:(error) => void) {
-            var configurationFile: string = fs.readFileSync(path.join(__dirname, "../config.json"), "utf8");
+            var configurationFile: string = fs.readFileSync(config.VORLON.ConfigProvider.getConfigPath(), "utf8");
             var configurationString = configurationFile.toString().replace(/^\uFEFF/, '');
             var configuration = JSON.parse(configurationString);
 
             if(!positions) {
                 return callback('Positions must be defined');
             }
-            
+
             positions = JSON.parse(positions);
             var lookup = {};
             var plugins_reorganised = [];
-            
+
             for (var i = 0; i < configuration.plugins.length; i++) {
                 lookup[configuration.plugins[i].id] = configuration.plugins[i];
             }
-            
+
             for (var i = 0; i < positions.length; i++) {
                 plugins_reorganised.push(lookup[positions[i]]);
             }
-            
-            configuration.plugins = plugins_reorganised;
-            
-            fs.writeFileSync(path.join(__dirname, "../config.json"), JSON.stringify(configuration, null, 4) ,"utf8");
 
-            
+            configuration.plugins = plugins_reorganised;
+
+            fs.writeFileSync(config.VORLON.ConfigProvider.getConfigPath(), JSON.stringify(configuration, null, 4) ,"utf8");
+
+
             return callback('PluginID unknown');
-        }        
+        }
     }
 }

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -28,8 +28,8 @@ if (!context.httpConfig.proxyEnvPort) {
     webServer.components.push(server);
     webServer.components.push(HttpProxy);
     webServer.start();
-} 
-else {    
+}
+else {
     var serverProxy = new vorlonHttpProxy.VORLON.HttpProxy(context, true);
     serverProxy.start();
 }

--- a/Server/server.ts
+++ b/Server/server.ts
@@ -4,7 +4,6 @@ import vorlonDashboard = require("./Scripts/vorlon.dashboard");
 import vorlonWebserver = require("./Scripts/vorlon.webServer");
 import vorlonHttpProxy = require("./Scripts/vorlon.httpproxy.server");
 import winstonLogger = require("./Scripts/vorlon.winstonlogger");
-//import argv = require('minimist');
 
 var context = new servercontext.VORLON.DefaultContext();
 


### PR DESCRIPTION
Allows users to pass in a path to a config file. Falling back to the one provided if no parameter specified. 

## Usage
```bash
$ vorlon --config sample_config.json
```