### PR TITLE
fixed script src is https source loding with httpss

### DIFF
--- a/Plugins/Vorlon/vorlon.clientPlugin.ts
+++ b/Plugins/Vorlon/vorlon.clientPlugin.ts
@@ -46,7 +46,7 @@
                 }
             }
             
-            if(Core.IsHttpsEnabled){
+            if(Core.IsHttpsEnabled && basedUrl.indexOf('https://') === -1){
                 basedUrl = basedUrl.replace(/^http/, "https");
             }
 


### PR DESCRIPTION
if html loading '<script src="https://0.0.0.0:1337/vorlon.js"></script>', `this.loadingDirectory.indexOf('http') === 0`  is `true`,  when code go to`if(Core.IsHttpsEnabled){ basedUrl = basedUrl.replace(/^http/, "https"); }`,  the prefix of `basedUrl`  is 'httpss://' ~~