### PR TITLE
Use path.resolve instead of path.join for loading ssl options

### DIFF
--- a/Server/config/vorlon.httpconfig.ts
+++ b/Server/config/vorlon.httpconfig.ts
@@ -30,8 +30,8 @@ export module VORLON {
                 this.protocol = "https";
                 this.httpModule = https;
                 this.options = {
-                    key: fs.readFileSync(path.join(__dirname, "../", catalog.SSLkey)),
-                    cert: fs.readFileSync(path.join(__dirname, "../", catalog.SSLcert))
+                    key: fs.readFileSync(path.resolve(__dirname, "../", catalog.SSLkey)),
+                    cert: fs.readFileSync(path.resolve(__dirname, "../", catalog.SSLcert))
                 }
             }
             else {


### PR DESCRIPTION
This is a breaking change if your key/crt started with a '/'
> path.join('/foo/bar', '../', 'baz')
'/foo/baz'
> path.join('/foo/bar', '../', '/baz')
'/foo/baz'
> path.resolve('/foo/bar', '../', 'baz')
'/foo/baz'
> path.resolve('/foo/bar', '../', '/baz')
'/baz'