### PR TITLE
Console improvements

### DIFF
--- a/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.client.ts
+++ b/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.client.ts
@@ -107,7 +107,9 @@
                 for (var i = 0, l = messages.length; i < l; i++) {
                     var msg = messages[i];
                     if (typeof msg === 'string' || typeof msg === 'number') {
-                        resmessages.push(msg);  
+                        resmessages.push(msg);
+                    } else if (typeof msg === 'undefined' || typeof msg === 'boolean') {
+                        resmessages.push(String(msg));
                     } else {
                         if (!Tools.IsWindowAvailable){
                             resmessages.push(this.inspect(msg, msg, 0));
@@ -172,12 +174,12 @@
             this._cache = [];
             this._pendingEntries = [];
             var console = Tools.IsWindowAvailable ? window.console : global.console;
-            
+
             // Overrides clear, log, error and warn
             this._hooks.clear = Tools.Hook(console, "clear",(): void => {
                 this.clearClientConsole();
             });
-            
+
             this._hooks.dir = Tools.Hook(console, "dir",(message: any): void => {
                 var data = {
                     messages: this.getMessages(message),
@@ -237,7 +239,7 @@
 
             Error = <any>((message: any) => {
                 var error = new previousError(message);
-                
+
                 var data = {
                     messages: this.getMessages(message),
                     type: "exception"
@@ -252,7 +254,7 @@
 
             if (Tools.IsWindowAvailable) {
                 window.addEventListener('error', (err) => {
-                    
+
                     if (err && (<any>err).error) {
                         //this.addEntry({ messages: [err.error.message], type: "exception" });
                         this.addEntry({ messages: [(<any>err).error.stack], type: "exception" });
@@ -269,14 +271,20 @@
         }
 
         public evalOrderFromDashboard(order: string) {
+            // Indirectly calling 'eval' causes it to execute in the global context.
+            var geval = eval;
+            var result;
+            console.log(order);
             try {
-                eval(order);
+                result = geval(order);
             } catch (e) {
-                console.error("Unable to execute order: " + e.message);
+                console.error(e.message);
+                return;
             }
+            console.log(result);
         }
 
-        public refresh(): void {           
+        public refresh(): void {
             //delay sending cache to dashboard to let other plugins load...
             setTimeout(() => {
                 this.sendCommandToDashboard("clear");

--- a/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.dashboard.ts
+++ b/Plugins/Vorlon/plugins/interactiveConsole/vorlon.interactiveConsole.dashboard.ts
@@ -10,7 +10,7 @@
             }
         }
 
-        // DASHBOARD        
+        // DASHBOARD
         private _clearButton: Element;
         private _containerDiv: HTMLElement;
         public _textFilter: HTMLInputElement;
@@ -35,8 +35,7 @@
                 this._interactiveInput.addEventListener("keydown", (evt) => {
                     if (evt.keyCode === 13) { //enter
                         this.sendCommandToClient('order', {
-                            order: this.isLoggable(this._interactiveInput.value) ? "console.log(" + this._interactiveInput.value + ")" 
-                                                                            : this._interactiveInput.value
+                            order: this._interactiveInput.value,
                         });
 
                         this._commandHistory.push(this._interactiveInput.value);
@@ -109,21 +108,6 @@
                 this._ready = true;
             });
         }
-        
-        private isLoggable(input:string) : boolean{
-            // "val" && 'val
-            if(input[0] == '"' &&  input[input.length - 1] == '"' || (input[0] == '\'' &&  input[input.length - 1] == '\''))
-                return true;
-                
-             if(input.indexOf('.') > 0){
-                 // .command, c.command(), c.command
-                 return (input.indexOf("(") > -1  && input.indexOf(")") > -1 ) ? false : true;
-             }  
-             
-             // funct("") => return something or not
-             // Other case, will return a console error from the client
-             return false;
-        }
 
         public addDashboardEntries(entries: ConsoleEntry[]) {
             for (var i = 0, l = entries.length; i < l; i++) {
@@ -191,7 +175,7 @@
             plugin._interactiveInput.value = "document.getElementById(\"" + data.order + "\")";
         }
     };
-        
+
     class InteractiveConsoleObject {
         obj: ObjectDescriptor;
         element: HTMLElement;
@@ -337,7 +321,6 @@
                 this.addMessage(entry.messages[i]);
             }
         }
-        
 
         private addMessage(msg: any) {
             if (typeof msg === 'string' || typeof msg === 'number') {


### PR DESCRIPTION
This pull request attempts to make the console plugin behave like a regular browser console:

1. We call an alias of `eval` which does the same thing but evaluates in the global scope. ( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#Description - see last example ). Otherwise I *think* if you try to define a variable, it's just defined in the local scope of `evalOrderFromDashboard`.
2. We call `console.log` on the command we're about to execute. This is just to leave a log of it in the console log. Again, to make it look like a normal console.
3. I removed the `isLoggable` logic and decided that all responses should be logged.
4. Removed "unable to execute order" - just show the error in the console!
5. Don't pass `boolean` or `undefined` types to inspect - just pass back as string. Think this should fix #419.

